### PR TITLE
Tmt 92 be 인플루언서 진행 캠페인 조회 기능 구현

### DIFF
--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/MainDashboardQueryController.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/MainDashboardQueryController.java
@@ -5,6 +5,8 @@ import be15fintomatokatchupbe.config.security.model.CustomUserDetail;
 import be15fintomatokatchupbe.dashboard.query.dto.response.QuotationResponse;
 import be15fintomatokatchupbe.dashboard.query.dto.response.*;
 import be15fintomatokatchupbe.dashboard.query.service.MainDashboardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "대시보드")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/dashboard")
@@ -21,6 +24,7 @@ public class MainDashboardQueryController {
 
     private final MainDashboardQueryService mainDashboardQueryService;
 
+    @Operation(summary = "신규 영업활동 조회", description = "사용자는 메인 대시보드에서 최근 30일 이내의 신규 영업활동 개수를 조회할 수 있다.")
     @GetMapping("/sales-activity")
     public ResponseEntity<ApiResponse<SalesActivityResponse>> getSalesActivity(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -28,6 +32,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "담당 고객사 조회", description = "사용자는 메인 대시보드에서 본인이 담당한 고객사의 목록을 조회할 수 있다.")
     @GetMapping("/client-company")
     public ResponseEntity<ApiResponse<List<ClientCompanyResponse>>> getClientCompany(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -35,6 +40,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "오늘 일정 조회", description = "사용자는 메인 대시보드에서 오늘의 일정을 조회할 수 있다.")
     @GetMapping("/schedule")
     public ResponseEntity<ApiResponse<List<TodayScheduleResponse>>> getTodaySchedule(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -42,6 +48,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "담당 리스트업 조회", description = "사용자는 메인 대시보드에서 자신이 담당한 리스트업의 목록을 조회할 수 있다.")
     @GetMapping("/list-up")
     public ResponseEntity<ApiResponse<List<ListupResponse>>> getListup(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -49,6 +56,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "담당 제안 조회", description = "사용자는 메인 대시보드에서 자신이 담당한 제안의 목록을 조회할 수 있다.")
     @GetMapping("/proposal")
     public ResponseEntity<ApiResponse<List<ProposalResponse>>> getProposal(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -56,6 +64,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "담당 계약 조회", description = "사용자는 메인 대시보드에서 자신이 담당한 계약의 목록을 조회할 수 있다.")
     @GetMapping("/contract")
     public ResponseEntity<ApiResponse<List<ContractResponse>>> getContract(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();
@@ -63,6 +72,7 @@ public class MainDashboardQueryController {
         return ResponseEntity.ok(ApiResponse.success(response));
     }
 
+    @Operation(summary = "담당 견적 조회", description = "사용자는 메인 대시보드에서 자신이 담당한 견적의 목록을 조회할 수 있다.")
     @GetMapping("/quotation")
     public ResponseEntity<ApiResponse<List<QuotationResponse>>> getQuotation(@AuthenticationPrincipal CustomUserDetail user) {
         Long userId = user.getUserId();

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/PlatformDashboardQueryController.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/PlatformDashboardQueryController.java
@@ -4,6 +4,8 @@ import be15fintomatokatchupbe.common.dto.ApiResponse;
 import be15fintomatokatchupbe.config.security.model.CustomUserDetail;
 import be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse;
 import be15fintomatokatchupbe.dashboard.query.service.PlatformDashboardQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,12 +16,14 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
 
+@Tag(name = "대시보드")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/dashboard")
 public class PlatformDashboardQueryController {
     private final PlatformDashboardQueryService platformDashboardQueryService;
 
+    @Operation(summary = "인플루언서 별 캠페인 조회", description = "사용자는 플랫폼 대시보드에서 해당 인플루언서가 진행했던 캠페인의 목록을 조회할 수 있다.")
     @GetMapping("/campaign/{influencerId}")
     public ResponseEntity<ApiResponse<List<CampaignResponse>>> getSalesActivity(
             @AuthenticationPrincipal CustomUserDetail user,

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/PlatformDashboardQueryController.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/controller/PlatformDashboardQueryController.java
@@ -1,0 +1,31 @@
+package be15fintomatokatchupbe.dashboard.query.controller;
+
+import be15fintomatokatchupbe.common.dto.ApiResponse;
+import be15fintomatokatchupbe.config.security.model.CustomUserDetail;
+import be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse;
+import be15fintomatokatchupbe.dashboard.query.service.PlatformDashboardQueryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/dashboard")
+public class PlatformDashboardQueryController {
+    private final PlatformDashboardQueryService platformDashboardQueryService;
+
+    @GetMapping("/campaign/{influencerId}")
+    public ResponseEntity<ApiResponse<List<CampaignResponse>>> getSalesActivity(
+            @AuthenticationPrincipal CustomUserDetail user,
+            @PathVariable Long influencerId
+    ) {
+        List<CampaignResponse> response = platformDashboardQueryService.getCampaignList(influencerId);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+}

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/dto/response/CampaignResponse.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/dto/response/CampaignResponse.java
@@ -1,0 +1,14 @@
+package be15fintomatokatchupbe.dashboard.query.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CampaignResponse {
+    private String clientCompanyName;
+    private String campaignName;
+    private String productName;
+    private String youtubeLink;
+    private String instagramLink;
+}

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/InstagramDashboardQueryMapper.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/InstagramDashboardQueryMapper.java
@@ -1,7 +1,0 @@
-package be15fintomatokatchupbe.dashboard.query.mapper;
-
-import org.apache.ibatis.annotations.Mapper;
-
-@Mapper
-public interface InstagramDashboardQueryMapper {
-}

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/PlatformDashboardQueryMapper.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/PlatformDashboardQueryMapper.java
@@ -1,0 +1,11 @@
+package be15fintomatokatchupbe.dashboard.query.mapper;
+
+import be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface PlatformDashboardQueryMapper {
+    List<CampaignResponse> findCampaignsByInfluencerId(Long influencerId);
+}

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/YoutubeDashboardQueryMapper.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/mapper/YoutubeDashboardQueryMapper.java
@@ -1,7 +1,0 @@
-package be15fintomatokatchupbe.dashboard.query.mapper;
-
-import org.apache.ibatis.annotations.Mapper;
-
-@Mapper
-public interface YoutubeDashboardQueryMapper {
-}

--- a/src/main/java/be15fintomatokatchupbe/dashboard/query/service/PlatformDashboardQueryService.java
+++ b/src/main/java/be15fintomatokatchupbe/dashboard/query/service/PlatformDashboardQueryService.java
@@ -1,0 +1,18 @@
+package be15fintomatokatchupbe.dashboard.query.service;
+
+import be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse;
+import be15fintomatokatchupbe.dashboard.query.mapper.PlatformDashboardQueryMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlatformDashboardQueryService {
+    private final PlatformDashboardQueryMapper platformDashboardQueryMapper;
+
+    public List<CampaignResponse> getCampaignList(Long influencerId) {
+        return platformDashboardQueryMapper.findCampaignsByInfluencerId(influencerId);
+    }
+}

--- a/src/main/resources/mappers/dashboard/InstagramDashboardQueryMapper.xml
+++ b/src/main/resources/mappers/dashboard/InstagramDashboardQueryMapper.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
-<mapper namespace="be15fintomatokatchupbe.dashboard.query.mapper.InstagramDashboardQueryMapper">
-
-
-</mapper>

--- a/src/main/resources/mappers/dashboard/PlatformDashboardQueryMapper.xml
+++ b/src/main/resources/mappers/dashboard/PlatformDashboardQueryMapper.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="be15fintomatokatchupbe.dashboard.query.mapper.PlatformDashboardQueryMapper">
+    <!--  인플루언서 진행 캠페인 조회  -->
+    <select id="findCampaignsByInfluencerId" resultType="be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse">
+        SELECT
+            cc.client_company_name           AS clientCompanyName,
+            c.campaign_name                 AS campaignName,
+            c.product_name                  AS productName,
+            picm.youtube_link               AS youtubeLink,
+            picm.instagram_link             AS instagramLink
+          FROM pipeline_influencer_client_manager picm
+        JOIN pipeline p ON picm.pipeline_id = p.pipeline_id
+        JOIN campaign c ON p.campaign_id = c.campaign_id
+        JOIN client_company cc ON c.client_company_id = cc.client_company_id
+        WHERE picm.influencer_id = #{influencerId}
+    </select>
+
+
+</mapper>

--- a/src/main/resources/mappers/dashboard/YoutubeDashboardQueryMapper.xml
+++ b/src/main/resources/mappers/dashboard/YoutubeDashboardQueryMapper.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<!DOCTYPE mapper
-        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
-
-<mapper namespace="be15fintomatokatchupbe.dashboard.query.mapper.YoutubeDashboardQueryMapper">
-
-
-</mapper>

--- a/src/test/java/be15fintomatokatchupbe/dashboard/query/service/MainDashboardQueryServiceTest.java
+++ b/src/test/java/be15fintomatokatchupbe/dashboard/query/service/MainDashboardQueryServiceTest.java
@@ -1,0 +1,158 @@
+package be15fintomatokatchupbe.dashboard.query.service;
+
+import be15fintomatokatchupbe.dashboard.query.dto.response.*;
+import be15fintomatokatchupbe.dashboard.query.mapper.MainDashboardQueryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class MainDashboardQueryServiceTest {
+    @Mock
+    private MainDashboardQueryMapper mainDashboardQueryMapper;
+
+    @InjectMocks
+    private MainDashboardQueryService mainDashboardQueryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getSalesActivity_success() {
+        Long userId = 1L;
+        SalesActivityResponse expected = SalesActivityResponse.builder()
+                .clientCompanyCount(3)
+                .influencerCount(5)
+                .contractCount(2)
+                .pipelineCount(4)
+                .build();
+
+        when(mainDashboardQueryMapper.countSalesActivities(userId)).thenReturn(expected);
+
+        SalesActivityResponse result = mainDashboardQueryService.getSalesActivity(userId);
+
+        assertEquals(3, result.getClientCompanyCount());
+        assertEquals(5, result.getInfluencerCount());
+        assertEquals(2, result.getContractCount());
+        assertEquals(4, result.getPipelineCount());
+    }
+
+    @Test
+    void getClientCompany_success() {
+        Long userId = 1L;
+        List<ClientCompanyResponse> expected = List.of(ClientCompanyResponse.builder()
+                .clientCompanyName("카카오")
+                .telephone("02-1234-0001")
+                .createdAt(LocalDateTime.now())
+                .statusName("기존")
+                .build());
+
+        when(mainDashboardQueryMapper.findClientCompanyByUserId(userId)).thenReturn(expected);
+
+        List<ClientCompanyResponse> result = mainDashboardQueryService.getClientCompany(userId);
+
+        assertEquals("카카오", result.get(0).getClientCompanyName());
+    }
+
+    @Test
+    void getTodaySchedule_success() {
+        Long userId = 1L;
+        List<TodayScheduleResponse> expected = List.of(TodayScheduleResponse.builder()
+                .content("회의")
+                .scheduleDate(LocalDate.of(2025, 6, 22))
+                .startTime(LocalTime.of(10, 0))
+                .endTime(LocalTime.of(11, 0))
+                .hexCode("#FF8A8A")
+                .build());
+
+        when(mainDashboardQueryMapper.findTodaySchedule(userId)).thenReturn(expected);
+
+        List<TodayScheduleResponse> result = mainDashboardQueryService.getTodaySchedule(userId);
+
+        assertEquals("#FF8A8A", result.get(0).getHexCode());
+    }
+
+    @Test
+    void getListupByUserId_success() {
+        Long userId = 1L;
+        List<ListupResponse> expected = List.of(ListupResponse.builder()
+                .companyName("네이버")
+                .contractName("계약 A")
+                .listupTitle("리스트업 A")
+                .clientManagerName("홍길동")
+                .clientManagerPosition("대리")
+                .build());
+
+        when(mainDashboardQueryMapper.findListupByUserId(userId)).thenReturn(expected);
+
+        List<ListupResponse> result = mainDashboardQueryService.getListupByUserId(userId);
+
+        assertEquals("리스트업 A", result.get(0).getListupTitle());
+    }
+
+    @Test
+    void getProposalByUserId_success() {
+        Long userId = 1L;
+        List<ProposalResponse> expected = List.of(ProposalResponse.builder()
+                .companyName("무신사")
+                .contractName("무신사 계약")
+                .proposalTitle("제안서1")
+                .clientManagerName("이수빈")
+                .clientManagerPosition("과장")
+                .statusName("승인요청")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        when(mainDashboardQueryMapper.findProposalByUserId(userId)).thenReturn(expected);
+
+        List<ProposalResponse> result = mainDashboardQueryService.getProposalByUserId(userId);
+
+        assertEquals("제안서1", result.get(0).getProposalTitle());
+    }
+
+    @Test
+    void getContractByUserId_success() {
+        Long userId = 1L;
+        List<ContractResponse> expected = List.of(ContractResponse.builder()
+                .companyName("삼성전자")
+                .contractName("Z 시리즈 계약")
+                .statusName("승인완료")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        when(mainDashboardQueryMapper.findContractByUserId(userId)).thenReturn(expected);
+
+        List<ContractResponse> result = mainDashboardQueryService.getContractByUserId(userId);
+
+        assertEquals("Z 시리즈 계약", result.get(0).getContractName());
+    }
+
+    @Test
+    void getQuotationByUserId_success() {
+        Long userId = 1L;
+        List<QuotationResponse> expected = List.of(QuotationResponse.builder()
+                .companyName("배달의민족")
+                .quotationName("배민 견적")
+                .expectedProfitMargin("25%")
+                .createdAt(LocalDateTime.now())
+                .build());
+
+        when(mainDashboardQueryMapper.findQuotationByUserId(userId)).thenReturn(expected);
+
+        List<QuotationResponse> result = mainDashboardQueryService.getQuotationByUserId(userId);
+
+        assertEquals("배달의민족", result.get(0).getCompanyName());
+        assertEquals("25%", result.get(0).getExpectedProfitMargin());
+    }
+}

--- a/src/test/java/be15fintomatokatchupbe/dashboard/query/service/PlatformDashboardQueryServiceTest.java
+++ b/src/test/java/be15fintomatokatchupbe/dashboard/query/service/PlatformDashboardQueryServiceTest.java
@@ -1,0 +1,52 @@
+package be15fintomatokatchupbe.dashboard.query.service;
+
+import be15fintomatokatchupbe.dashboard.query.dto.response.CampaignResponse;
+import be15fintomatokatchupbe.dashboard.query.mapper.PlatformDashboardQueryMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class PlatformDashboardQueryServiceTest {
+    @Mock
+    private PlatformDashboardQueryMapper platformDashboardQueryMapper;
+
+    @InjectMocks
+    private PlatformDashboardQueryService platformDashboardQueryService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
+
+    @Test
+    void getCampaignList_shouldReturnCampaigns() {
+        Long influencerId = 1L;
+        List<CampaignResponse> expected = List.of(
+                CampaignResponse.builder()
+                        .clientCompanyName("카카오엔터프라이즈")
+                        .campaignName("카카오 AI 패키지 홍보")
+                        .productName("AI 번역기 Pro")
+                        .youtubeLink("https://youtube.com/example1")
+                        .instagramLink("https://instagram.com/example1")
+                        .build()
+        );
+
+        when(platformDashboardQueryMapper.findCampaignsByInfluencerId(influencerId)).thenReturn(expected);
+
+        List<CampaignResponse> result = platformDashboardQueryService.getCampaignList(influencerId);
+
+        assertEquals(1, result.size());
+        assertEquals("카카오엔터프라이즈", result.get(0).getClientCompanyName());
+        assertEquals("카카오 AI 패키지 홍보", result.get(0).getCampaignName());
+        assertEquals("AI 번역기 Pro", result.get(0).getProductName());
+        verify(platformDashboardQueryMapper).findCampaignsByInfluencerId(influencerId);
+    }
+}


### PR DESCRIPTION
[변경사항]
- 인플루언서 별 진행 캠페인 조회 기능 구현
- 스웨거 작성
- 테스트 코드 추가
- 
[테스트 결과]
<img width="714" alt="스크린샷 2025-06-22 오후 6 40 52" src="https://github.com/user-attachments/assets/f7f92465-0788-4b3f-95c0-b4fc52d54601" />
