### PR TITLE
TMT 166 be 파이프라인 의견 삭제 기능 구현

### DIFF
--- a/src/main/java/be15fintomatokatchupbe/campaign/command/application/controller/IdeaCommandController.java
+++ b/src/main/java/be15fintomatokatchupbe/campaign/command/application/controller/IdeaCommandController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "캠페인 의견")
+@Tag(name = "캠페인 파이프라인 의견")
 @RestController
 @Slf4j
 @AllArgsConstructor
@@ -26,15 +26,15 @@ public class IdeaCommandController {
     private final IdeaCommandService ideaCommandService;
     private final UserHelperService userHelperService;
 
-    // 견적 의견 삭제 기능
-    @Operation(summary = "견적 의견 삭제", description = "사용자는 견적에 작성된 의견을 삭제할 수 있다.(soft delete)")
-    @DeleteMapping("quotation/{ideaId}")
-    public ResponseEntity<ApiResponse<Void>> deleteQuotationIdea(
+    // 파이프라인 의견 삭제 기능
+    @Operation(summary = "파이프라인 의견 삭제", description = "사용자는 파이프라인에 작성된 의견을 삭제할 수 있다.(soft delete)")
+    @DeleteMapping("{ideaId}")
+    public ResponseEntity<ApiResponse<Void>> deleteIdea(
             @AuthenticationPrincipal CustomUserDetail customUserDetail,
             @PathVariable Long ideaId
     ){
         User user = userHelperService.findValidUser(customUserDetail.getUserId());
-        ideaCommandService.deleteQuotationIdea(user, ideaId);
+        ideaCommandService.deleteIdea(user, ideaId);
         return ResponseEntity.ok(ApiResponse.success(null));
     }
 }

--- a/src/main/java/be15fintomatokatchupbe/campaign/command/application/service/IdeaCommandService.java
+++ b/src/main/java/be15fintomatokatchupbe/campaign/command/application/service/IdeaCommandService.java
@@ -7,7 +7,6 @@ import be15fintomatokatchupbe.common.domain.StatusType;
 import be15fintomatokatchupbe.common.exception.BusinessException;
 import be15fintomatokatchupbe.user.command.application.repository.UserRepository;
 import be15fintomatokatchupbe.user.command.domain.aggregate.User;
-import be15fintomatokatchupbe.user.exception.UserErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +18,7 @@ public class IdeaCommandService {
     private final UserRepository userRepository;
 
     @Transactional
-    public void deleteQuotationIdea(User user, Long ideaId) {
+    public void deleteIdea(User user, Long ideaId) {
         // 삭제 여부 관계 없이 먼저 찾고
         Idea idea = ideaRepository.findById(ideaId)
                 .orElseThrow(() -> new BusinessException(CampaignErrorCode.IDEA_NOT_FOUND));

--- a/src/main/java/be15fintomatokatchupbe/campaign/command/domain/repository/IdeaRepository.java
+++ b/src/main/java/be15fintomatokatchupbe/campaign/command/domain/repository/IdeaRepository.java
@@ -1,8 +1,6 @@
 package be15fintomatokatchupbe.campaign.command.domain.repository;
 
 import be15fintomatokatchupbe.campaign.command.domain.aggregate.entity.Idea;
-import be15fintomatokatchupbe.common.domain.StatusType;
-import be15fintomatokatchupbe.user.command.domain.aggregate.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;


### PR DESCRIPTION
파이프라인(제안, 견적, 계약, 매출) 의견 삭제 기능 구현
![PR용 파이프라인 의견 삭제](https://github.com/user-attachments/assets/aa2eddeb-1fdb-4674-bd05-825e6bfdca4c)
![PR용 파이프라인 의견 삭제 DB](https://github.com/user-attachments/assets/c543cfe0-0fb1-4b77-ba28-fda1d78225ae)
![PR용 파이프라인 의견 삭제 에러코드](https://github.com/user-attachments/assets/2708c129-7d20-4dfd-860c-6132752fa283)
http://localhost:8080/api/v1/campaign/idea/{ideaId} 로 전부 통일.
