### PR TITLE
Fix: 응답일 null일때만 채우기

### DIFF
--- a/src/main/java/be15fintomatokatchupbe/email/command/application/service/EmailCommendService.java
+++ b/src/main/java/be15fintomatokatchupbe/email/command/application/service/EmailCommendService.java
@@ -104,7 +104,9 @@ public class EmailCommendService {
                     .orElseThrow(() -> new BusinessException(EmailErrorCode.NOT_FOUND_SATISFACTION));
 
             entity.setScore(sum);
-            entity.setResponseDate(new Date());
+            if(entity.getResponseDate() == null) {
+                entity.setResponseDate(new Date());
+            }
             entity.setNotes(notes);
             entity.setIsReacted(StatusType.Y);
 


### PR DESCRIPTION
기존에 조회하면 조회한 날로 계속 업데이트 됐는데 
조회햇을때 한번만 채워지게